### PR TITLE
Update OpenHIM Core Service name

### DIFF
--- a/packages/cdr/docker/importer/docker-compose.config.yml
+++ b/packages/cdr/docker/importer/docker-compose.config.yml
@@ -18,7 +18,7 @@ services:
         source: instant
         target: /instant
     # This command will only attempt to import the OpenHIM config when the heartbeat responds with a 2xx
-    command: sh -c "wait-on -t 60000 https-get://core:8080/heartbeat && node /instant/cdr/docker/importer/volume/openhimConfig.js"
+    command: sh -c "wait-on -t 60000 https-get://openhim-core:8080/heartbeat && node /instant/cdr/docker/importer/volume/openhimConfig.js"
 
   kibana-config-importer:
     container_name: kibana-config-importer


### PR DESCRIPTION
The Service and container names now match to prevent confusion is
future.
This reference was using the old service name

DIO-106